### PR TITLE
[#17]Feat: 이메일 인증 구현

### DIFF
--- a/Sparky-iOS.xcodeproj/project.pbxproj
+++ b/Sparky-iOS.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		564938F928E8B55E00861D26 /* EmailSignInRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564938F828E8B55E00861D26 /* EmailSignInRequest.swift */; };
 		564938FB28E8B56B00861D26 /* EmailSignInResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564938FA28E8B56B00861D26 /* EmailSignInResponse.swift */; };
 		564938FE28E8BAE100861D26 /* HTTPUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564938FD28E8BAE100861D26 /* HTTPUtils.swift */; };
+		56902D1728EA9B70005F18B1 /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56902D1628EA9B70005F18B1 /* SignUpViewModel.swift */; };
+		56902D1A28EAC527005F18B1 /* OTPTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56902D1928EAC527005F18B1 /* OTPTextField.swift */; };
+		56902D1C28EAC595005F18B1 /* OTPStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56902D1B28EAC595005F18B1 /* OTPStackView.swift */; };
 		5693C1F628CE2CDC008710FF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5693C1F528CE2CDC008710FF /* AppDelegate.swift */; };
 		5693C1F828CE2CDC008710FF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5693C1F728CE2CDC008710FF /* SceneDelegate.swift */; };
 		5693C1FA28CE2CDC008710FF /* SigninVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5693C1F928CE2CDC008710FF /* SigninVC.swift */; };
@@ -99,6 +102,9 @@
 		564938F828E8B55E00861D26 /* EmailSignInRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSignInRequest.swift; sourceTree = "<group>"; };
 		564938FA28E8B56B00861D26 /* EmailSignInResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSignInResponse.swift; sourceTree = "<group>"; };
 		564938FD28E8BAE100861D26 /* HTTPUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPUtils.swift; sourceTree = "<group>"; };
+		56902D1628EA9B70005F18B1 /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
+		56902D1928EAC527005F18B1 /* OTPTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPTextField.swift; sourceTree = "<group>"; };
+		56902D1B28EAC595005F18B1 /* OTPStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPStackView.swift; sourceTree = "<group>"; };
 		5693C1F228CE2CDC008710FF /* Sparky-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Sparky-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5693C1F528CE2CDC008710FF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5693C1F728CE2CDC008710FF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -254,6 +260,7 @@
 		5616C53F28DB730200BF7126 /* Custom */ = {
 			isa = PBXGroup;
 			children = (
+				56902D1828EAC50F005F18B1 /* OTPField */,
 				5616C54028DB730200BF7126 /* Shareing */,
 			);
 			path = Custom;
@@ -294,6 +301,15 @@
 				564938FD28E8BAE100861D26 /* HTTPUtils.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		56902D1828EAC50F005F18B1 /* OTPField */ = {
+			isa = PBXGroup;
+			children = (
+				56902D1928EAC527005F18B1 /* OTPTextField.swift */,
+				56902D1B28EAC595005F18B1 /* OTPStackView.swift */,
+			);
+			path = OTPField;
 			sourceTree = "<group>";
 		};
 		5693C1E928CE2CDC008710FF = {
@@ -360,6 +376,7 @@
 				56A6FAF228E4BB4B009EA038 /* SignUpVC2.swift */,
 				56DE426628E20E91000A6A55 /* SignUpVC3.swift */,
 				56DE426828E20E9A000A6A55 /* SignUpVC4.swift */,
+				56902D1628EA9B70005F18B1 /* SignUpViewModel.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -658,14 +675,17 @@
 				564938FB28E8B56B00861D26 /* EmailSignInResponse.swift in Sources */,
 				56DE426B28E21547000A6A55 /* UINavigationBar+.swift in Sources */,
 				5637DD3928E0291D00C119F6 /* Image+.swift in Sources */,
+				56902D1728EA9B70005F18B1 /* SignUpViewModel.swift in Sources */,
 				56C7B20528E9463600D638D2 /* UserServiceProvider.swift in Sources */,
 				56DE426528E1F9ED000A6A55 /* SignUpVC1.swift in Sources */,
 				5693C1F828CE2CDC008710FF /* SceneDelegate.swift in Sources */,
 				564938FE28E8BAE100861D26 /* HTTPUtils.swift in Sources */,
+				56902D1A28EAC527005F18B1 /* OTPTextField.swift in Sources */,
 				560BF31D28D0DAB300438463 /* UITextField+.swift in Sources */,
 				56DE426928E20E9A000A6A55 /* SignUpVC4.swift in Sources */,
 				56DE426728E20E91000A6A55 /* SignUpVC3.swift in Sources */,
 				564938F728E8B55200861D26 /* EmailSignIn.swift in Sources */,
+				56902D1C28EAC595005F18B1 /* OTPStackView.swift in Sources */,
 				56C7B20928E9710400D638D2 /* EmailSignInView.swift in Sources */,
 				564938F928E8B55E00861D26 /* EmailSignInRequest.swift in Sources */,
 			);

--- a/Sparky-iOS/Custom/OTPField/OTPStackView.swift
+++ b/Sparky-iOS/Custom/OTPField/OTPStackView.swift
@@ -1,0 +1,155 @@
+//
+//  OTPStackView.swift
+//  Sparky-iOS
+//
+//  Created by SeungMin on 2022/10/03.
+//
+
+import Foundation
+import UIKit
+
+protocol OTPDelegate: AnyObject {
+    func didChangeValidity(isValid: Bool)
+}
+
+class OTPStackView: UIStackView {
+    
+    // Customise the OTP Field here
+    let numberOfFields = 6
+    var textFieldsCollection: [OTPTextField] = []
+    weak var delegate: OTPDelegate?
+    var showsWarningColor = false
+    
+    var remainingStringStack: [String] = []
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStackView()
+        setupStackView()
+        addOTPField()
+    }
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private final func setupStackView() {
+        self.backgroundColor = .sparkyWhite
+        self.isUserInteractionEnabled = true
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.contentMode = .center
+        self.distribution = .fillEqually
+        self.spacing = 10
+    }
+    
+    private final func addOTPField() {
+        for index in 0..<numberOfFields {
+            let field = OTPTextField()
+            setupTextField(field)
+            textFieldsCollection.append(field)
+            
+            // Adding a marker to previous field
+            index != 0 ? (field.previousTextField = textFieldsCollection[index - 1]) : (field.previousTextField = nil)
+            // Adding a marker to next field for the field at index - 1
+            index != 0 ? (textFieldsCollection[index - 1].nextTextField = field) : ()
+        }
+        textFieldsCollection[0].becomeFirstResponder()
+    }
+    
+    private final func setupTextField(_ textField: OTPTextField) {
+        textField.delegate = self
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        self.addArrangedSubview(textField)
+        textField.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+        textField.heightAnchor.constraint(equalTo: self.heightAnchor).isActive = true
+        textField.backgroundColor = .sparkyWhite
+        textField.textAlignment = .center
+        textField.adjustsFontSizeToFitWidth = false
+        textField.font = .bodyRegular2
+        textField.textColor = .sparkyBlack
+        textField.layer.cornerRadius = 8
+        textField.layer.borderWidth = 1
+        textField.layer.borderColor = UIColor.sparkyBlack.cgColor
+        textField.keyboardType = .numberPad
+        textField.autocorrectionType = .yes
+        textField.textContentType = .oneTimeCode
+    }
+    
+    private final func checkForValidity() {
+        for fields in textFieldsCollection {
+            if fields.text == "" {
+                delegate?.didChangeValidity(isValid: false)
+                return
+            }
+        }
+        delegate?.didChangeValidity(isValid: true)
+    }
+    
+    final func getOTP() -> String {
+        var OTP = ""
+        for textField in textFieldsCollection {
+            OTP += textField.text ?? ""
+        }
+        return OTP
+    }
+    
+    final func setAllFieldColor(isWarningColor: Bool = false, color: UIColor) {
+        for textField in textFieldsCollection {
+            textField.layer.borderColor = color.cgColor
+        }
+        showsWarningColor = isWarningColor
+    }
+    
+    private final func autoFillTextField(with string: String) {
+        remainingStringStack = string.reversed().compactMap({ String($0) })
+        for textField in textFieldsCollection {
+            if let charToAdd = remainingStringStack.popLast() {
+                textField.text = String(charToAdd)
+            } else {
+                break
+            }
+        }
+        checkForValidity()
+        remainingStringStack = []
+    }
+}
+
+extension OTPStackView: UITextFieldDelegate {
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if showsWarningColor {
+//            setAllFieldColor(color: .sparkyOrange)
+            showsWarningColor = false
+        }
+        textField.layer.borderColor = UIColor.sparkyBlack.cgColor
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        checkForValidity()
+//        textField.layer.borderColor = UIColor.orange.cgColor
+    }
+    
+    func textField(_ textField: UITextField,
+                   shouldChangeCharactersIn range: NSRange,
+                   replacementString string: String) -> Bool {
+        guard let textField = textField as? OTPTextField else { return true }
+        if string.count > 1 {
+            textField.resignFirstResponder()
+            autoFillTextField(with: string)
+            return false
+        } else {
+            if range.length == 0 {
+                if textField.nextTextField == nil {
+                    textField.text? = string
+                    textField.resignFirstResponder()
+                } else {
+                    textField.text? = string
+                    textField.nextTextField?.becomeFirstResponder()
+                }
+                return false
+            }
+            return true
+        }
+    }
+}

--- a/Sparky-iOS/Custom/OTPField/OTPTextField.swift
+++ b/Sparky-iOS/Custom/OTPField/OTPTextField.swift
@@ -1,0 +1,18 @@
+//
+//  OTPTextField.swift
+//  Sparky-iOS
+//
+//  Created by SeungMin on 2022/10/03.
+//
+
+import UIKit
+
+class OTPTextField: UITextField {
+    weak var previousTextField: OTPTextField?
+    weak var nextTextField: OTPTextField?
+    
+    override public func deleteBackward() {
+        text = ""
+        previousTextField?.becomeFirstResponder()
+    }
+}

--- a/Sparky-iOS/Scenes/SignUp/SignUpVC2.swift
+++ b/Sparky-iOS/Scenes/SignUp/SignUpVC2.swift
@@ -6,10 +6,14 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 class SignUpVC2: UIViewController {
     
     // MARK: - Properties
+    let viewModel = SignUpViewModel()
+    let disposeBag = DisposeBag()
     private let navigationEdgeBar = UIView().then {
         $0.backgroundColor = .gray200
     }
@@ -23,28 +27,41 @@ class SignUpVC2: UIViewController {
         $0.font = .subTitleBold3
         $0.textColor = .sparkyBlack
     }
+
+//    private let emailTextField = UITextField().then {
+//        $0.font = .bodyRegular2
+//        $0.textColor = .sparkyBlack
+//        $0.attributedPlaceholder(text: "이메일을 입력해주세요",
+//                                 color: .gray400,
+//                                 font: .bodyRegular2)
+//        $0.layer.borderWidth = 1
+//        $0.layer.borderColor = UIColor.gray300.cgColor
+//        $0.layer.cornerRadius = 8
+//        $0.setLeftPadding(20)
+//        $0.clearButtonMode = .whileEditing
+//    }
     
-    private let emailTextField = UITextField().then {
+    private let otpStackView = OTPStackView()
+//        .then {
+//        $0.showsWarningColor = true
+//        $0.setAllFieldColor(color: .sparkyBlack)
+//    }
+    
+    private let errorLabel = UILabel().then {
+        $0.text = "한굴, 영어, 숫자로 2~16글자"
         $0.font = .bodyRegular2
         $0.textColor = .sparkyBlack
-        $0.attributedPlaceholder(text: "이메일을 입력해주세요",
-                                 color: .gray400,
-                                 font: .bodyRegular2)
-        $0.layer.borderWidth = 1
-        $0.layer.borderColor = UIColor.gray300.cgColor
-        $0.layer.cornerRadius = 8
-        $0.setLeftPadding(20)
     }
     
-    private let authEmailButton = UIButton().then {
-        $0.setTitle("인증메일 받기", for: .normal)
+    private let nextButton = UIButton().then {
+        $0.setTitle("인증 완료", for: .normal)
         $0.setTitleColor(.sparkyWhite, for: .normal)
         $0.titleLabel?.font = .bodyBold2
         $0.layer.cornerRadius = 8
         $0.backgroundColor = .sparkyBlack
-        $0.addTarget(self,
-                     action: #selector(didTapNextButton),
-                     for: .touchUpInside)
+//        $0.addTarget(self,
+//                     action: #selector(didTapNextButton),
+//                     for: .touchUpInside)
     }
     
     // MARK: - LifeCycles
@@ -55,6 +72,7 @@ class SignUpVC2: UIViewController {
         
         setupNavBar()
         setupUI()
+        bindViewModel()
     }
     
     private func setupNavBar() {
@@ -92,16 +110,22 @@ class SignUpVC2: UIViewController {
             $0.left.equalTo(view).offset(20)
         }
         
-        view.addSubview(emailTextField)
-        emailTextField.snp.makeConstraints {
+        view.addSubview(otpStackView)
+        otpStackView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(20)
             $0.left.equalTo(view).offset(20)
             $0.right.equalTo(view).offset(-20)
             $0.height.equalTo(50)
         }
         
-        view.addSubview(authEmailButton)
-        authEmailButton.snp.makeConstraints {
+        view.addSubview(errorLabel)
+        errorLabel.snp.makeConstraints {
+            $0.top.equalTo(otpStackView.snp.bottom).offset(12)
+            $0.left.equalTo(view).offset(20)
+        }
+        
+        view.addSubview(nextButton)
+        nextButton.snp.makeConstraints {
             $0.left.equalTo(view).offset(20)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-20)
             $0.right.equalTo(view).offset(-20)
@@ -109,12 +133,39 @@ class SignUpVC2: UIViewController {
         }
     }
     
-    @objc private func didTapBackButton() {
-        self.navigationController?.popViewController(animated: true)
+    private func bindViewModel() {
+//        otpStackView.textFieldsCollection[0].
+//
+//            .bind(to: viewModel.valueObserver)
+//            .disposed(by: disposeBag)
+        
+//        viewModel.isValid(regexType: .email)
+//            .bind(to: nextButton.rx.isEnabled)
+//            .disposed(by: disposeBag)
+        
+//        viewModel.isEmpty(regexType: .email)
+//            .map { $0 ? UIColor.gray300.cgColor : UIColor.sparkyOrange.cgColor }
+//            .bind(to: emailTextField.layer.rx.borderColor)
+//            .disposed(by: disposeBag)
+//
+//        viewModel.isEmpty(regexType: .email)
+//            .map { $0 ? true : false }
+//            .bind(to: conditionLabel.rx.isHidden)
+//            .disposed(by: disposeBag)
+//
+//        viewModel.isValid(regexType: .email)
+//            .map { $0 ? .black : .gray300 }
+//            .bind(to: nextButton.rx.backgroundColor)
+//            .disposed(by: disposeBag)
+        
+        nextButton.rx.tap
+            .bind { _ in
+                let signUpVC3 = SignUpVC3()
+                self.navigationController?.pushViewController(signUpVC3, animated: true)
+            }.disposed(by: disposeBag)
     }
     
-    @objc private func didTapNextButton() {
-        let signUpVC3 = SignUpVC3()
-        self.navigationController?.pushViewController(signUpVC3, animated: true)
+    @objc private func didTapBackButton() {
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/Sparky-iOS/Scenes/SignUp/SignUpVC3.swift
+++ b/Sparky-iOS/Scenes/SignUp/SignUpVC3.swift
@@ -6,10 +6,14 @@
 //
 
 import UIKit
+import RxSwift
 
 class SignUpVC3: UIViewController {
     
     // MARK: - Properties
+    let viewModel = SignUpViewModel()
+    let disposeBag = DisposeBag()
+    
     private let navigationEdgeBar = UIView().then {
         $0.backgroundColor = .gray200
     }
@@ -34,10 +38,25 @@ class SignUpVC3: UIViewController {
         $0.layer.borderColor = UIColor.gray300.cgColor
         $0.layer.cornerRadius = 8
         $0.setLeftPadding(20)
+        $0.clearButtonMode = .whileEditing
+    }
+    
+    private let textStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 12
+    }
+    
+    private let errorLabel = UILabel().then {
+        $0.text = "올바르지 않은 비밀번호 형식입니다."
+        $0.font = .bodyRegular2
+        $0.textColor = .sparkyOrange
+        $0.isHidden = true
+        $0.layoutIfNeeded()
+        $0.layoutIfNeeded()
     }
     
     private let conditionLabel = UILabel().then {
-        $0.text = "한굴, 영어, 숫자로 2~16글자"
+        $0.text = "영문/숫자포함 8~20자"
         $0.font = .bodyRegular2
         $0.textColor = .sparkyBlack
     }
@@ -48,9 +67,6 @@ class SignUpVC3: UIViewController {
         $0.titleLabel?.font = .bodyBold2
         $0.layer.cornerRadius = 8
         $0.backgroundColor = .sparkyBlack
-        $0.addTarget(self,
-                     action: #selector(didTapNextButton),
-                     for: .touchUpInside)
     }
     
     // MARK: - LifeCycles
@@ -61,6 +77,7 @@ class SignUpVC3: UIViewController {
         
         setupNavBar()
         setupUI()
+        bindViewModel()
     }
     
     private func setupNavBar() {
@@ -106,11 +123,14 @@ class SignUpVC3: UIViewController {
             $0.height.equalTo(50)
         }
         
-        view.addSubview(conditionLabel)
-        conditionLabel.snp.makeConstraints {
+        view.addSubview(textStackView)
+        textStackView.snp.makeConstraints {
             $0.top.equalTo(passwordTextField.snp.bottom).offset(12)
             $0.left.equalTo(view).offset(20)
         }
+        
+        textStackView.addArrangedSubview(errorLabel)
+        textStackView.addArrangedSubview(conditionLabel)
         
         view.addSubview(nextButton)
         nextButton.snp.makeConstraints {
@@ -121,12 +141,40 @@ class SignUpVC3: UIViewController {
         }
     }
     
-    @objc private func didTapBackButton() {
-        self.navigationController?.popViewController(animated: true)
+    private func bindViewModel() {
+        passwordTextField.rx.text
+            .orEmpty
+            .bind(to: viewModel.valueObserver)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .password)
+            .map { $0 == .none ? UIColor.gray300.cgColor : $0 == .valid ? UIColor.sparkyBlack.cgColor : UIColor.sparkyOrange.cgColor }
+            .bind(to: passwordTextField.layer.rx.borderColor)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .password)
+            .map { $0 == .none || $0 == .valid ? true : false }
+            .bind(to: errorLabel.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .password)
+            .map { $0 == .valid }
+            .bind(to: nextButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .password)
+            .map { $0 == .valid ? .sparkyBlack : .gray300 }
+            .bind(to: nextButton.rx.backgroundColor)
+            .disposed(by: disposeBag)
+        
+        nextButton.rx.tap
+            .bind { _ in
+                let signUpVC4 = SignUpVC4()
+                self.navigationController?.pushViewController(signUpVC4, animated: true)
+            }.disposed(by: disposeBag)
     }
     
-    @objc private func didTapNextButton() {
-        let signUpVC4 = SignUpVC4()
-        self.navigationController?.pushViewController(signUpVC4, animated: true)
+    @objc private func didTapBackButton() {
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/Sparky-iOS/Scenes/SignUp/SignUpVC4.swift
+++ b/Sparky-iOS/Scenes/SignUp/SignUpVC4.swift
@@ -6,10 +6,14 @@
 //
 
 import UIKit
+import RxSwift
 
 class SignUpVC4: UIViewController {
     
     // MARK: - Properties
+    let viewModel = SignUpViewModel()
+    let disposeBag = DisposeBag()
+    
     private let navigationEdgeBar = UIView().then {
         $0.backgroundColor = .gray200
     }
@@ -34,10 +38,23 @@ class SignUpVC4: UIViewController {
         $0.layer.borderColor = UIColor.gray300.cgColor
         $0.layer.cornerRadius = 8
         $0.setLeftPadding(20)
+        $0.clearButtonMode = .whileEditing
+    }
+    
+    private let textStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 12
+    }
+    
+    private let errorLabel = UILabel().then {
+        $0.text = "올바르지 않은 비밀번호 형식입니다."
+        $0.font = .bodyRegular2
+        $0.textColor = .sparkyOrange
+        $0.isHidden = true
     }
     
     private let conditionLabel = UILabel().then {
-        $0.text = "영문, 한글, 숫자 6~18자"
+        $0.text = "한글, 영어, 숫자 2~16자"
         $0.font = .bodyRegular2
         $0.textColor = .sparkyBlack
     }
@@ -48,9 +65,6 @@ class SignUpVC4: UIViewController {
         $0.titleLabel?.font = .bodyBold2
         $0.layer.cornerRadius = 8
         $0.backgroundColor = .sparkyBlack
-        $0.addTarget(self,
-                     action: #selector(didTapNextButton),
-                     for: .touchUpInside)
     }
     
     // MARK: - LifeCycles
@@ -61,6 +75,7 @@ class SignUpVC4: UIViewController {
         
         setupNavBar()
         setupUI()
+        bindViewModel()
     }
     
     private func setupNavBar() {
@@ -106,11 +121,14 @@ class SignUpVC4: UIViewController {
             $0.height.equalTo(50)
         }
         
-        view.addSubview(conditionLabel)
-        conditionLabel.snp.makeConstraints {
+        view.addSubview(textStackView)
+        textStackView.snp.makeConstraints {
             $0.top.equalTo(nicknameTextField.snp.bottom).offset(12)
             $0.left.equalTo(view).offset(20)
         }
+        
+        textStackView.addArrangedSubview(errorLabel)
+        textStackView.addArrangedSubview(conditionLabel)
         
         view.addSubview(nextButton)
         nextButton.snp.makeConstraints {
@@ -118,15 +136,43 @@ class SignUpVC4: UIViewController {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-20)
             $0.right.equalTo(view).offset(-20)
             $0.height.equalTo(50)
-            
         }
+    }
+    
+    private func bindViewModel() {
+        nicknameTextField.rx.text
+            .orEmpty
+            .bind(to: viewModel.valueObserver)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .nickname)
+            .map { $0 == .none ? UIColor.gray300.cgColor : $0 == .valid ? UIColor.sparkyBlack.cgColor : UIColor.sparkyOrange.cgColor }
+            .bind(to: nicknameTextField.layer.rx.borderColor)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .nickname)
+            .map { $0 == .none || $0 == .valid ? true : false }
+            .bind(to: errorLabel.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .nickname)
+            .map { $0 == .valid }
+            .bind(to: nextButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValid(regexType: .nickname)
+            .map { $0 == .valid ? .sparkyBlack : .gray300 }
+            .bind(to: nextButton.rx.backgroundColor)
+            .disposed(by: disposeBag)
+        
+        nextButton.rx.tap
+            .bind { _ in
+//                let signUpVC2 = SignUpVC2()
+//                self.navigationController?.pushViewController(signUpVC2, animated: true)
+            }.disposed(by: disposeBag)
     }
     
     @objc private func didTapBackButton() {
         self.navigationController?.popViewController(animated: true)
-    }
-    
-    @objc private func didTapNextButton() {
-        
     }
 }

--- a/Sparky-iOS/Scenes/SignUp/SignUpViewModel.swift
+++ b/Sparky-iOS/Scenes/SignUp/SignUpViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  NextButtonViewModel.swift
+//  Sparky-iOS
+//
+//  Created by SeungMin on 2022/10/03.
+//
+
+import RxSwift
+import RxCocoa
+
+enum RegexType {
+    case email
+    case password
+    case nickname
+
+    var value: String {
+        switch self {
+        case .email:
+            return "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        case .password:
+            return "[A-Za-z0-9!_@$%^&+=]{8,20}"
+        case .nickname:
+            return "[가-힣A-Za-z0-9]{2,16}"
+        }
+    }
+}
+
+enum TextType {
+    case none
+    case valid
+    case invalid
+}
+
+final class SignUpViewModel {
+    let valueObserver = BehaviorRelay<String>(value: "")
+
+    func isValid(regexType: RegexType) -> Observable<TextType> {
+        return Observable.combineLatest(valueObserver, valueObserver).map { value1, value2 in
+            if value1 != "" {
+                if NSPredicate(format: "SELF MATCHES %@", regexType.value).evaluate(with: value1) {
+                    return TextType.valid
+                } else { return TextType.invalid }
+            } else { return TextType.none }
+        }.startWith(TextType.none)
+    }
+    
+//    func isValid(regexType: RegexType) -> Observable<TextType> {
+//        return Observable.combineLatest(valueObserver, valueObserver).map { value1, value2 in
+//            if NSPredicate(format: "SELF MATCHES %@", regexType.value).evaluate(with: value1) {
+//                return true
+//            } else { return false }
+//        }.startWith(false)
+//    }
+}


### PR DESCRIPTION
- OTP 숫자 입력 필드 UI 구현
- 입력을 안 한 경우, 했는데 규칙에 안 맞는 경우, 규칙에 맞는 경우 세가지 나누어서 처리
- 회원가입 비밀 번호, 닉네임 화면에서 텍스트가 hidden이 됐을 때 아예 사라지도록 stackView로 구현
- 텍스트 필드에 clear 버튼 구현

# 제목의 길이는 최대 40글자까지 한글로 간단 명료하게 작성
# 제목을 작성하고 반드시 빈 줄 한 줄을 만들어야 함 # 제목에 .(마침표) 금지
# <label> 리스트
# Feat: 새로운 기능
# Fix: 버그 수정
# Update: Swift 파일 (생성, 삭제, 이동, 이름 변경)
# Style: 코드 스타일 혹은 포맷 등에 관한 커밋
# Docs: 문서 (md 파일 추가, 수정, 삭제)
# Refactor: 코드 가독성과 유지 보수의 편의에 관한 커밋
# Test: 테스트
# <description>
# 내용의 길이는 한 줄당 60글자 내외에서 줄 바꿈. 한글로 간단 명료하게 작성
# 어떻게 보다는 무엇을, 왜 변경했는지를 작성할 것 (필수)
# <issue-number>
# 연관된 이슈 첨부, 여러 개 추가 가능