### PR TITLE
[# ]Feat: 티스토리 크롤링해서 썸네일, 타이틀, 서브 타이틀 가져오도록 구현

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,6 +8,8 @@ def shared_pods
   pod 'RxSwift'
   pod 'RxCocoa'
   pod 'Moya/RxSwift'
+  pod 'Alamofire'
+  pod 'SwiftSoup'
 end
 
 target 'Sparky-iOS' do

--- a/Sparky-iOS.xcodeproj/project.pbxproj
+++ b/Sparky-iOS.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		564938F928E8B55E00861D26 /* EmailSignInRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564938F828E8B55E00861D26 /* EmailSignInRequest.swift */; };
 		564938FB28E8B56B00861D26 /* EmailSignInResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564938FA28E8B56B00861D26 /* EmailSignInResponse.swift */; };
 		564938FE28E8BAE100861D26 /* HTTPUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564938FD28E8BAE100861D26 /* HTTPUtils.swift */; };
+		5652A44628EB303F00415738 /* CrawlManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5652A44528EB303F00415738 /* CrawlManager.swift */; };
+		5652A44828EB31D400415738 /* Scrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5652A44728EB31D400415738 /* Scrap.swift */; };
+		5652A44C28EB4FA800415738 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5652A44A28EB3CE000415738 /* Strings.swift */; };
+		5652A44D28EB4FAA00415738 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5652A44A28EB3CE000415738 /* Strings.swift */; };
 		56902D1728EA9B70005F18B1 /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56902D1628EA9B70005F18B1 /* SignUpViewModel.swift */; };
 		56902D1A28EAC527005F18B1 /* OTPTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56902D1928EAC527005F18B1 /* OTPTextField.swift */; };
 		56902D1C28EAC595005F18B1 /* OTPStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56902D1B28EAC595005F18B1 /* OTPStackView.swift */; };
@@ -102,6 +106,9 @@
 		564938F828E8B55E00861D26 /* EmailSignInRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSignInRequest.swift; sourceTree = "<group>"; };
 		564938FA28E8B56B00861D26 /* EmailSignInResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSignInResponse.swift; sourceTree = "<group>"; };
 		564938FD28E8BAE100861D26 /* HTTPUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPUtils.swift; sourceTree = "<group>"; };
+		5652A44528EB303F00415738 /* CrawlManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlManager.swift; sourceTree = "<group>"; };
+		5652A44728EB31D400415738 /* Scrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrap.swift; sourceTree = "<group>"; };
+		5652A44A28EB3CE000415738 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		56902D1628EA9B70005F18B1 /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 		56902D1928EAC527005F18B1 /* OTPTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPTextField.swift; sourceTree = "<group>"; };
 		56902D1B28EAC595005F18B1 /* OTPStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPStackView.swift; sourceTree = "<group>"; };
@@ -291,6 +298,7 @@
 				564938F628E8B55200861D26 /* EmailSignIn.swift */,
 				564938F828E8B55E00861D26 /* EmailSignInRequest.swift */,
 				564938FA28E8B56B00861D26 /* EmailSignInResponse.swift */,
+				5652A44728EB31D400415738 /* Scrap.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -301,6 +309,22 @@
 				564938FD28E8BAE100861D26 /* HTTPUtils.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		5652A44428EB2FE100415738 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				5652A44528EB303F00415738 /* CrawlManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
+		5652A44928EB3CD100415738 /* Strings */ = {
+			isa = PBXGroup;
+			children = (
+				5652A44A28EB3CE000415738 /* Strings.swift */,
+			);
+			path = Strings;
 			sourceTree = "<group>";
 		};
 		56902D1828EAC50F005F18B1 /* OTPField */ = {
@@ -339,6 +363,8 @@
 		5693C1F428CE2CDC008710FF /* Sparky-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				5652A44928EB3CD100415738 /* Strings */,
+				5652A44428EB2FE100415738 /* Manager */,
 				564938FC28E8BA2E00861D26 /* Utils */,
 				564938F428E8B3E800861D26 /* Model */,
 				564938F128E8985B00861D26 /* Service */,
@@ -655,6 +681,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				5616C54728DB739500BF7126 /* CustomShareVC.swift in Sources */,
+				5652A44828EB31D400415738 /* Scrap.swift in Sources */,
+				5652A44C28EB4FA800415738 /* Strings.swift in Sources */,
+				5652A44628EB303F00415738 /* CrawlManager.swift in Sources */,
 				5616C54828DB739800BF7126 /* CustomShareNC.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -683,6 +712,7 @@
 				56902D1A28EAC527005F18B1 /* OTPTextField.swift in Sources */,
 				560BF31D28D0DAB300438463 /* UITextField+.swift in Sources */,
 				56DE426928E20E9A000A6A55 /* SignUpVC4.swift in Sources */,
+				5652A44D28EB4FAA00415738 /* Strings.swift in Sources */,
 				56DE426728E20E91000A6A55 /* SignUpVC3.swift in Sources */,
 				564938F728E8B55200861D26 /* EmailSignIn.swift in Sources */,
 				56902D1C28EAC595005F18B1 /* OTPStackView.swift in Sources */,

--- a/Sparky-iOS/Custom/Shareing/CustomShareVC.swift
+++ b/Sparky-iOS/Custom/Shareing/CustomShareVC.swift
@@ -21,17 +21,26 @@ final class CustomShareVC: UIViewController {
     private let scrapView = UIView()
     private let scrapImageView = UIImageView().then {
         $0.image = UIImage(systemName: "person.circle")
+        $0.contentMode = .scaleAspectFill
     }
-    private let scrapTitleLabel = UILabel().then {
+    
+    private var scrapTitleLabel = UILabel().then {
         $0.text = "스으으으으으크크크크크크크크으으으으으으으으래래래래래애애애애애앱~~~~~"
-        $0.font = .systemFont(ofSize: 20)
+        $0.font = .systemFont(ofSize: 16)
         $0.textAlignment = .center
         $0.textColor = .black
         $0.lineBreakMode = .byWordWrapping
         $0.numberOfLines = 0
     }
     
-    
+    private var scrapSubTitleLabel = UILabel().then {
+        $0.text = "스으으으으으크크크크크크크크으으으으으으으으래래래래래애애애애애앱~~~~~"
+        $0.font = .systemFont(ofSize: 14)
+        $0.textAlignment = .left
+        $0.textColor = .black
+//        $0.lineBreakMode = .byWordWrapping
+        $0.numberOfLines = 3
+    }
     
     // MARK: - LifeCycles
     override func viewDidLoad() {
@@ -82,17 +91,17 @@ final class CustomShareVC: UIViewController {
     private func setupScrapView() {
         self.view.addSubview(scrapView)
         scrapView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(24)
-            $0.left.equalTo(view.safeAreaLayoutGuide.snp.left).offset(16)
-            $0.right.equalTo(view.safeAreaLayoutGuide.snp.right).offset(-16)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.left.equalTo(view).offset(16)
+            $0.right.equalTo(view).offset(-16)
             $0.height.equalTo(80)
         }
         
         self.scrapView.addSubview(scrapImageView)
         scrapImageView.snp.makeConstraints {
-            $0.top.equalTo(scrapView.snp.top)
-            $0.left.equalTo(scrapView.snp.left)
-            $0.bottom.equalTo(scrapView.snp.bottom)
+            $0.top.equalTo(scrapView)
+            $0.left.equalTo(scrapView)
+            $0.bottom.equalTo(scrapView)
             $0.width.equalTo(80)
         }
         
@@ -100,8 +109,15 @@ final class CustomShareVC: UIViewController {
         scrapTitleLabel.snp.makeConstraints {
             $0.top.equalTo(scrapView.snp.top)
             $0.left.equalTo(scrapImageView.snp.right).offset(16)
-            $0.bottom.equalTo(scrapView.snp.bottom)
-            $0.right.equalTo(scrapView.snp.right)
+            $0.right.equalTo(scrapView)
+        }
+        
+        self.scrapView.addSubview(scrapSubTitleLabel)
+        scrapSubTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(scrapTitleLabel.snp.bottom).offset(7)
+            $0.left.equalTo(scrapImageView.snp.right).offset(16)
+            $0.bottom.equalTo(scrapView)
+            $0.right.equalTo(scrapView)
         }
         
         //        if let item = extensionContext?.inputItems.first as? NSExtensionItem,
@@ -142,18 +158,20 @@ final class CustomShareVC: UIViewController {
         }
         
         if let attachments = extentionItem.attachments {
-            print("attachments is not nil")
-            
             for attachment: NSItemProvider in attachments {
-                print("attachment - \(attachment)")
                 if attachment.hasItemConformingToTypeIdentifier("public.url") {
-                    print("hasItemConformingToTypeIdentifier is true")
-                    attachment.loadItem(forTypeIdentifier: "public.url", options: nil) { (url, error) in
-                        print("loadItem")
-                        print(url, error)
-                        if let url = url as? NSURL {
+                    attachment.loadItem(forTypeIdentifier: "public.url",
+                                        options: nil) { (url, error) in
+                        
+                        print("url - \(url)")
+                        
+                        if let url = url as? URL {
                             DispatchQueue.main.async {
-//                                self.scrapTitleLabel.text = url.path
+                                CrwalManager().getTistoryScrap(url: url) { scrap in
+                                    self.scrapImageView.image = UIImage(data: try! Data(contentsOf: scrap.thumbnailURL))
+                                    self.scrapTitleLabel.text = scrap.title
+                                    self.scrapSubTitleLabel.text = scrap.subTitle
+                                }
                             }
                             
                         }

--- a/Sparky-iOS/Manager/CrawlManager.swift
+++ b/Sparky-iOS/Manager/CrawlManager.swift
@@ -1,0 +1,72 @@
+//
+//  CrawlManager.swift
+//  Sparky
+//
+//  Created by SeungMin on 2022/10/03.
+//
+
+import Alamofire
+import SwiftSoup
+
+enum NetworkError: Error {
+    case invalidURL
+    case invlidRequest
+    case invalidResponse
+    case emptyHTML
+    case failure
+    case parsingError
+    
+}
+
+final class CrwalManager {
+    func getTistoryScrap(url: URL?,
+                         completion: @escaping (Scrap) -> Void) {
+        var scrap = Scrap(thumbnailURL: URL(string: Strings.sparkyImageString)!,
+                          title: "",
+                          subTitle: "")
+        
+        guard let url = url else {
+            print(NetworkError.invalidURL)
+            return
+        }
+
+        AF.request(url).responseString { response in
+            if response.error != nil {
+                print(NetworkError.failure)
+                return
+            }
+            
+            guard let html = response.value else {
+                print(NetworkError.emptyHTML)
+                return
+            }
+            
+            do {
+                let document: Document = try SwiftSoup.parse(html)
+                let elements: Elements = try document.select(Strings.tistoryBaseSector)
+                let array = elements.array()
+                
+                var thumbnailURL = URL(string: Strings.sparkyImageString)!
+                var title = ""
+                var subTitle = ""
+                
+                for i in 0..<array.count {
+                    print("index - \(i)")
+                    let thumbnailURLString = try array[i].select(Strings.tistoryThumbnailSector).attr("src")
+                    thumbnailURL = URL(string: thumbnailURLString)!
+                    title = try array[i].select(Strings.tistoryTitleSector).text()
+                    subTitle += try array[i].select(Strings.tistorySubTitleSector).text()
+                }
+                
+                scrap = Scrap(thumbnailURL: thumbnailURL,
+                              title: title,
+                              subTitle: subTitle)
+                print("scrap - \(scrap)")
+                completion(scrap)
+            } catch {
+                print(NetworkError.parsingError)
+            }
+            
+        }
+    }
+}

--- a/Sparky-iOS/Model/EmailSignIn.swift
+++ b/Sparky-iOS/Model/EmailSignIn.swift
@@ -5,7 +5,7 @@
 //  Created by SeungMin on 2022/10/02.
 //
 
-//struct EmailSignIn {
-//    let email: String
-//    let password: String
-//}
+struct EmailSignIn {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Sparky-iOS/Model/Scrap.swift
+++ b/Sparky-iOS/Model/Scrap.swift
@@ -1,0 +1,14 @@
+//
+//  Scrap.swift
+//  Sparky
+//
+//  Created by SeungMin on 2022/10/04.
+//
+
+import Foundation
+
+struct Scrap {
+    let thumbnailURL: URL
+    let title: String
+    let subTitle: String
+}

--- a/Sparky-iOS/Service/UserServiceAPI.swift
+++ b/Sparky-iOS/Service/UserServiceAPI.swift
@@ -6,7 +6,6 @@
 //
 
 import Moya
-import Foundation
 
 enum UserServiceAPI {
     case signIn(body: EmailSignInRequest)

--- a/Sparky-iOS/Service/UserServiceProvider.swift
+++ b/Sparky-iOS/Service/UserServiceProvider.swift
@@ -8,7 +8,7 @@
 import Moya
 import RxSwift
 
-class UserServiceProvider {
+final class UserServiceProvider {
     static var shared = UserServiceProvider()
     
     let provider = MoyaProvider<UserServiceAPI>()

--- a/Sparky-iOS/Strings/Strings.swift
+++ b/Sparky-iOS/Strings/Strings.swift
@@ -1,0 +1,38 @@
+//
+//  Strings.swift
+//  Sparky-iOS
+//
+//  Created by SeungMin on 2022/10/04.
+//
+
+enum Strings {
+    static let tistoryBaseSector = "#mArticle > div"
+    static let tistoryThumbnailSector = "div.area_view > div > figure:nth-child(30) > span > img"
+    static let tistoryTitleSector = "div.area_title > h3 > a"
+    static let tistorySubTitleSector = "div.area_view > div > p"
+    static let sparkyImageString = "https://user-images.githubusercontent.com/68800789/193646098-51860dec-c5ad-4c39-be80-c9ef5daac7ad.png"
+}
+//#mArticle > div > div.area_title > h3 > a
+//#mArticle > div.area_title > h3
+//#container > main > div > div.area-view > div.article-header > div > div > h2
+//#content > div.inner > div.post-cover > div > h1
+//
+//head > title
+//head > title
+//
+//
+//
+//#mArticle > div > div.area_view > div > figure:nth-child(31) > span > img
+//#mArticle > div.area_view > div > figure:nth-child(15) > span > img
+//#container > main > div > div.area-view > div.article-view > div > figure:nth-child(14) > span > img
+//#container > main > div > div.area-view > div.article-header
+//#content > div.inner > div.post-cover > div
+
+//썸네일
+//#mArticle > div > div.area_view > div > figure:nth-child(30) > span > img
+//#content > div.inner > div.post-cover
+
+// 타이틀
+//#mArticle > div > div.area_title > h3 > a
+//#container > main > div > div.area-view > div.article-header > div > div > h2
+

--- a/Sparky-iOS/Utils/HTTPUtils.swift
+++ b/Sparky-iOS/Utils/HTTPUtils.swift
@@ -8,9 +8,9 @@
 enum HTTPUtils {
 //    case signin = "signin"
     
-    static var baseUrl: String {
-        get { "https://sparky-demo.herokuapp.com" }
-    }
+//    static var baseUrl: String {
+//        get { "https://sparky-demo.herokuapp.com" }
+//    }
     
 //    var path: String {
 //        switch self {


### PR DESCRIPTION
- SwiftSoup, Alamorifre를 이용해서 크롤링 구현
- custom한 웹페이지가 많아서 규칙을 찾기 어려워 다시 시도해 볼 것.

# 제목의 길이는 최대 40글자까지 한글로 간단 명료하게 작성
# 제목을 작성하고 반드시 빈 줄 한 줄을 만들어야 함 # 제목에 .(마침표) 금지
# <label> 리스트
# Feat: 새로운 기능
# Fix: 버그 수정
# Update: Swift 파일 (생성, 삭제, 이동, 이름 변경)
# Style: 코드 스타일 혹은 포맷 등에 관한 커밋
# Docs: 문서 (md 파일 추가, 수정, 삭제)
# Refactor: 코드 가독성과 유지 보수의 편의에 관한 커밋
# Test: 테스트
# <description>
# 내용의 길이는 한 줄당 60글자 내외에서 줄 바꿈. 한글로 간단 명료하게 작성
# 어떻게 보다는 무엇을, 왜 변경했는지를 작성할 것 (필수)
# <issue-number>
# 연관된 이슈 첨부, 여러 개 추가 가능