### PR TITLE
[#98]Fix: 태그 컬렉션 뷰 스크롤 안 되도록 수정

### DIFF
--- a/Sparky-iOS/Custom/Shareing/TagCollectionView.swift
+++ b/Sparky-iOS/Custom/Shareing/TagCollectionView.swift
@@ -32,6 +32,7 @@ class TagCollectionView: UICollectionView {
     
     private func setupUI() {
         backgroundColor = .sparkyWhite
+        isScrollEnabled = false
         
         self.register(TagCollectionViewCell.self,
                       forCellWithReuseIdentifier: TagCollectionViewCell.identifier)


### PR DESCRIPTION
- 컬렉션 뷰 init 시, isScrollEnabled = false 추가
- 현재 재연은 안 되서 릴리즈 후 테스트해볼 것

# 제목의 길이는 최대 40글자까지 한글로 간단 명료하게 작성
# 제목을 작성하고 반드시 빈 줄 한 줄을 만들어야 함 # 제목에 .(마침표) 금지
# <label> 리스트
# Feat: 새로운 기능
# Fix: 버그 수정
# Update: Swift 파일 (생성, 삭제, 이동, 이름 변경)
# Style: 코드 스타일 혹은 포맷 등에 관한 커밋
# Docs: 문서 (md 파일 추가, 수정, 삭제)
# Refactor: 코드 가독성과 유지 보수의 편의에 관한 커밋
# Test: 테스트
# <description>
# 내용의 길이는 한 줄당 60글자 내외에서 줄 바꿈. 한글로 간단 명료하게 작성
# 어떻게 보다는 무엇을, 왜 변경했는지를 작성할 것 (필수)
# <issue-number>
# 연관된 이슈 첨부, 여러 개 추가 가능